### PR TITLE
trcstore: search query match on CompactFileLine

### DIFF
--- a/trcstore/collector.go
+++ b/trcstore/collector.go
@@ -127,10 +127,10 @@ func (c *Collector) Search(ctx context.Context, req *SearchRequest) (*SearchResp
 	for category, rb := range c.categories.GetAll() {
 		// TODO: could do these concurrently
 		var categorySelected []*SearchTrace
-		rb.Walk(func(tr trc.Trace) error {
+		rb.Walk(func(candidate trc.Trace) error {
 			// Every trace should update the total, and be observed by stats.
 			total++
-			stats.Observe(tr)
+			stats.Observe(candidate)
 
 			// If we already have the max number of traces from this category,
 			// then we won't select any more. We do this first, because it's
@@ -140,12 +140,12 @@ func (c *Collector) Search(ctx context.Context, req *SearchRequest) (*SearchResp
 			}
 
 			// If the request won't allow this trace, then we won't select it.
-			if !req.Allow(ctx, tr) {
+			if !req.Allow(ctx, candidate) {
 				return nil
 			}
 
 			// Otherwise, collect a static copy of the trace.
-			categorySelected = append(categorySelected, NewSearchTrace(tr))
+			categorySelected = append(categorySelected, NewSearchTrace(candidate))
 			return nil
 		})
 		tr.LazyTracef("processed category=%s categorySelected=%d", category, len(categorySelected))

--- a/trcstore/search.go
+++ b/trcstore/search.go
@@ -227,7 +227,7 @@ func (req *SearchRequest) Allow(ctx context.Context, tr trc.Trace) bool {
 				if req.regexp.MatchString(c.Function) {
 					return true
 				}
-				if req.regexp.MatchString(c.FileLine) {
+				if req.regexp.MatchString(c.CompactFileLine()) {
 					return true
 				}
 			}


### PR DESCRIPTION
Matching on the complete file and line could return confusing results, where traces were being returned by a search without any obvious reason why.